### PR TITLE
feat: add ccusage plugin and integrate with lualine

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -19,3 +19,4 @@ asdf set deno latest
 asdf plugin add nodejs
 asdf install nodejs latest
 asdf set nodejs latest
+npm install -g ccusage

--- a/vim/lua/plugins/ccusage.lua
+++ b/vim/lua/plugins/ccusage.lua
@@ -1,0 +1,7 @@
+local ccusage = {
+  "S1M0N38/ccusage.nvim",
+  version = "1.*",
+  opts = {},
+}
+
+return ccusage

--- a/vim/lua/plugins/lualine.lua
+++ b/vim/lua/plugins/lualine.lua
@@ -4,6 +4,9 @@ local lualine_config = function()
     options = {
       theme = theme,
     },
+    sections = {
+      lualine_x = { "ccusage" },
+    },
   })
 end
 local lualine = {


### PR DESCRIPTION
- Added `ccusage.nvim` plugin for code usage statistics.
- Installed `ccusage` globally via npm in `setup.sh`.
- Integrated `ccusage` into the `lualine` status line.